### PR TITLE
Fixed continue button and text problem

### DIFF
--- a/ForgetMeNot/Assets/Scenes/Scene1.unity
+++ b/ForgetMeNot/Assets/Scenes/Scene1.unity
@@ -268,7 +268,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &555554623
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1233,7 +1233,7 @@ MonoBehaviour:
   - 'Nino: (Ughh this light is so bright ...)'
   - 'Nino: (My head is killing me..)'
   typingSpeed: 0.02
-  continueButton: {fileID: 0}
+  continueButton: {fileID: 555554622}
 --- !u!4 &1884922938
 Transform:
   m_ObjectHideFlags: 0

--- a/ForgetMeNot/Assets/Scenes/Scene2.unity
+++ b/ForgetMeNot/Assets/Scenes/Scene2.unity
@@ -159,7 +159,7 @@ MonoBehaviour:
   - 'Unknown1: Jesus Christ...'
   - 'Unknown2: What?'
   typingSpeed: 0.02
-  continueButton: {fileID: 0}
+  continueButton: {fileID: 174905296}
 --- !u!4 &96869881
 Transform:
   m_ObjectHideFlags: 0
@@ -192,7 +192,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &174905297
 RectTransform:
   m_ObjectHideFlags: 0

--- a/ForgetMeNot/Assets/Scenes/Scene3.unity
+++ b/ForgetMeNot/Assets/Scenes/Scene3.unity
@@ -341,7 +341,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1115177214
 RectTransform:
   m_ObjectHideFlags: 0
@@ -552,7 +552,7 @@ MonoBehaviour:
   - 'Unknown2: Anyways, don''t even think about going soft on me.'
   - 'Unknown 2: You had just as much to do with this as I did.'
   typingSpeed: 0
-  continueButton: {fileID: 0}
+  continueButton: {fileID: 1115177213}
 --- !u!4 &1197127396
 Transform:
   m_ObjectHideFlags: 0

--- a/ForgetMeNot/Assets/Scenes/Scene4.unity
+++ b/ForgetMeNot/Assets/Scenes/Scene4.unity
@@ -861,7 +861,7 @@ MonoBehaviour:
   - 'Unknown2: It''s a little too early for that Nino.'
   - 'Nino: (Nino? That''s...me. How does he know my name?)'
   typingSpeed: 0.02
-  continueButton: {fileID: 0}
+  continueButton: {fileID: 1733300163}
 --- !u!4 &1322956380
 Transform:
   m_ObjectHideFlags: 0
@@ -1143,7 +1143,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1733300164
 RectTransform:
   m_ObjectHideFlags: 0

--- a/ForgetMeNot/Assets/Scenes/Scene5.unity
+++ b/ForgetMeNot/Assets/Scenes/Scene5.unity
@@ -643,7 +643,7 @@ MonoBehaviour:
   - 'Unknown2: Shut up will you! It''ll be hell for us if he wakes up now.'
   - 'Unknown2: I''m just putting him back to sleep is all.'
   typingSpeed: 0.02
-  continueButton: {fileID: 0}
+  continueButton: {fileID: 1780634713}
 --- !u!4 &759872492
 Transform:
   m_ObjectHideFlags: 0
@@ -1141,7 +1141,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1780634714
 RectTransform:
   m_ObjectHideFlags: 0

--- a/ForgetMeNot/Assets/Scenes/Scene6.unity
+++ b/ForgetMeNot/Assets/Scenes/Scene6.unity
@@ -159,7 +159,7 @@ MonoBehaviour:
   - 'Nino: (No...I''m...getting so tired...all of a...sudden...)'
   - 'Nino: ......'
   typingSpeed: 0
-  continueButton: {fileID: 0}
+  continueButton: {fileID: 566386946}
 --- !u!4 &286040409
 Transform:
   m_ObjectHideFlags: 0
@@ -322,7 +322,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &566386947
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Continue button automatically disables until the end of the text. Prevents letters being jumbled up and misplaced in the dialogue.